### PR TITLE
Aem-bootcamp-13: adding custom image

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/image/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/image/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Component"
+    jcr:title="image"
+    sling:resourceSuperType="core/wcm/components/image/v3/image"
+    componentGroup="AEM Bootcamp Site - Content"/>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/image/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/image/.content.xml
@@ -3,4 +3,4 @@
     jcr:primaryType="cq:Component"
     jcr:title="image"
     sling:resourceSuperType="core/wcm/components/image/v3/image"
-    componentGroup="AEM Bootcamp Site - Content"/>
+    componentGroup="AEM Bootcamp Site - General"/>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/image/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/image/.content.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:description="This is Image component for AEM Bootcamp sites"
     jcr:primaryType="cq:Component"
-    jcr:title="image"
+    jcr:title="Image"
     sling:resourceSuperType="core/wcm/components/image/v3/image"
-    componentGroup="AEM Bootcamp Site - General"/>
+    componentGroup="AEM Bootcamp General"/>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/image/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/image/_cq_dialog/.content.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Image"
+    sling:resourceType="cq/gui/components/authoring/dialog"
+    extraClientlibs="[core.wcm.components.image.v3.editor,core.wcm.components.commons.editor.dialog.pageimagethumbnail.v1]"
+    helpPath="https://www.adobe.com/go/aem_cmp_image_v3"
+    trackingFeature="core-components:image:v3">
+    <content
+        granite:class="cmp-image__editor"
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="granite/ui/components/coral/foundation/container">
+        <items jcr:primaryType="nt:unstructured">
+            <tabs
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/coral/foundation/tabs"
+                maximized="{Boolean}true">
+                <items jcr:primaryType="nt:unstructured">
+                    <metadata
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Metadata"
+                        sling:hideResource="{Boolean}true"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true"/>
+                    <asset
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Asset"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <columns
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                margin="{Boolean}true">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <column
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <link
+                                                granite:class="cmp-image__editor-link"
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/container">
+                                                <items jcr:primaryType="nt:unstructured">
+                                                    <link
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                                                        path="/mnt/overlay/core/wcm/components/commons/editor/dialog/link/v1/link/edit/link"/>
+                                                </items>
+                                            </link>
+                                            <disableLazyLoading
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:hideResource="{Boolean}true"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                checked="${not empty cqDesign.disableLazyLoading ? cqDesign.disableLazyLoading : false}"
+                                                fieldDescription="When checked, it will preload all images, without using lazy loading."
+                                                name="./disableLazyLoading"
+                                                text="Disable lazy loading"
+                                                uncheckedValue="false"
+                                                value="{Boolean}true"/>
+                                        </items>
+                                    </column>
+                                </items>
+                            </columns>
+                        </items>
+                    </asset>
+                </items>
+            </tabs>
+        </items>
+    </content>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/image/_cq_editConfig.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/image/_cq_editConfig.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    cq:inherit="{Boolean}true"
-    jcr:primaryType="cq:EditConfig"/>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/image/_cq_editConfig.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/image/_cq_editConfig.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    cq:inherit="{Boolean}true"
+    jcr:primaryType="cq:EditConfig"/>


### PR DESCRIPTION
This is to add a custom image with the following attributes:

- fileReference –fileupload, Required (should not have browse option)
- altText –textfield, Required
- imgLink –pathbrowser.

![image](https://github.com/altperf/aem-bootcamp/assets/136115127/031009fe-dab3-4411-ab72-3e96a3312776)
