### PR TITLE
aem-bootcamp-12:adding custom separator

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/separator/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/separator/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:description="This is Separator component for AEM Bootcamp sites"
+    jcr:primaryType="cq:Component"
+    jcr:title="Separator"
+    sling:resourceSuperType="core/wcm/components/separator/v1/separator"
+    componentGroup="AEM Bootcamp General"/>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/separator/clientlibs/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/separator/clientlibs/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/separator/clientlibs/site/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/separator/clientlibs/site/.content.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    categories="[aem-bootcamp.components.general.separator,aem-bootcamp.site]"/>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/separator/clientlibs/site/css.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/separator/clientlibs/site/css.txt
@@ -1,0 +1,4 @@
+
+#base=css
+
+bootcamp.css

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/separator/clientlibs/site/css/bootcamp.css
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/separator/clientlibs/site/css/bootcamp.css
@@ -1,0 +1,62 @@
+.bootcamp-separator-hide {
+	display: none;
+	visibility: hidden;
+}
+
+.bootcamp-separator-show {
+	display: block;
+	visibility: visible;
+}
+
+
+.bootcamp-separator-color-grey {
+	color: #808080;
+}
+
+.bootcamp-separator-color-black {
+	color: #000000;
+}
+
+.bootcamp-separator-color-white {
+	color: #FFFFFF;
+}
+
+.bootcamp-separator-color-yellow {
+	color: #FFFF00;
+}
+
+.bootcamp-separator-color-red {
+	color: #FF0000;
+}
+
+.bootcamp-separator-color-blue {
+	color: #0000FF;
+}
+
+div.bootcamp-separator-width-30 > div > hr.cmp-separator__horizontal-rule {
+	width: 30%;
+}
+
+div.bootcamp-separator-width-50 > div > hr.cmp-separator__horizontal-rule {
+	width: 50%;
+}
+
+div.bootcamp-separator-width-80 > div > hr.cmp-separator__horizontal-rule {
+	width: 80%;
+}
+
+div.bootcamp-separator-width-100 > div > hr.cmp-separator__horizontal-rule {
+	width: 100%;
+}
+
+div.bootcamp-separator-solid > div > hr.cmp-separator__horizontal-rule {
+	border-style: solid;
+}
+
+div.bootcamp-separator-dashed > div > hr.cmp-separator__horizontal-rule {
+	border-style: dashed;
+}
+
+div.bootcamp-separator-dotted > div > hr.cmp-separator__horizontal-rule {
+	border-style: dotted;
+}

--- a/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/separator/clientlibs/site/css/bootcamp.css
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-bootcamp/components/general/separator/clientlibs/site/css/bootcamp.css
@@ -9,27 +9,27 @@
 }
 
 
-.bootcamp-separator-color-grey {
+div.bootcamp-separator-color-grey > div > hr.cmp-separator__horizontal-rule {
 	color: #808080;
 }
 
-.bootcamp-separator-color-black {
+div.bootcamp-separator-color-black > div > hr.cmp-separator__horizontal-rule {
 	color: #000000;
 }
 
-.bootcamp-separator-color-white {
+div.bootcamp-separator-color-white > div > hr.cmp-separator__horizontal-rule {
 	color: #FFFFFF;
 }
 
-.bootcamp-separator-color-yellow {
+div.bootcamp-separator-color-yellow > div > hr.cmp-separator__horizontal-rule {
 	color: #FFFF00;
 }
 
-.bootcamp-separator-color-red {
+div.bootcamp-separator-color-red > div > hr.cmp-separator__horizontal-rule {
 	color: #FF0000;
 }
 
-.bootcamp-separator-color-blue {
+div.bootcamp-separator-color-blue > div > hr.cmp-separator__horizontal-rule {
 	color: #0000FF;
 }
 

--- a/ui.content/src/main/content/jcr_root/conf/aem-bootcamp/settings/wcm/policies/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/aem-bootcamp/settings/wcm/policies/.content.xml
@@ -13,7 +13,12 @@
                         jcr:title="Content Form"
                         sling:resourceType="wcm/core/components/policy/policy"
                         components="[/apps/aem-bootcamp/components/form/button,/apps/aem-bootcamp/components/form/hidden,/apps/aem-bootcamp/components/form/options,/apps/aem-bootcamp/components/form/text]">
-                        <jcr:content jcr:primaryType="nt:unstructured"/>
+                        <jcr:content
+                            cq:lastReplicated="{Date}2023-06-20T17:56:40.892-06:00"
+                            cq:lastReplicatedBy="admin"
+                            cq:lastReplicationAction="Activate"
+                            jcr:mixinTypes="[cq:ReplicationStatus]"
+                            jcr:primaryType="nt:unstructured"/>
                     </form-container>
                 </container>
             </form>
@@ -34,15 +39,20 @@
                     jcr:title="Content Image"
                     sling:resourceType="wcm/core/components/policy/policy"
                     allowedRenditionWidths="[320,480,600,800,1024,1200,1600]"
-                    disableLazyLoading="false"
                     allowUpload="false"
                     altValueFromDAM="true"
+                    disableLazyLoading="false"
                     displayPopupTitle="true"
                     isDecorative="false"
                     jpegQuality="{Long}85"
                     titleValueFromDAM="true"
                     uuidDisabled="true">
-                    <jcr:content jcr:primaryType="nt:unstructured"/>
+                    <jcr:content
+                        cq:lastReplicated="{Date}2023-06-20T17:56:40.892-06:00"
+                        cq:lastReplicatedBy="admin"
+                        cq:lastReplicationAction="Activate"
+                        jcr:mixinTypes="[cq:ReplicationStatus]"
+                        jcr:primaryType="nt:unstructured"/>
                     <plugins jcr:primaryType="nt:unstructured">
                         <crop
                             jcr:primaryType="nt:unstructured"
@@ -80,7 +90,12 @@
                     jcr:primaryType="nt:unstructured"
                     jcr:title="Content Text"
                     sling:resourceType="wcm/core/components/policy/policy">
-                    <jcr:content jcr:primaryType="nt:unstructured"/>
+                    <jcr:content
+                        cq:lastReplicated="{Date}2023-06-20T17:56:40.892-06:00"
+                        cq:lastReplicatedBy="admin"
+                        cq:lastReplicationAction="Activate"
+                        jcr:mixinTypes="[cq:ReplicationStatus]"
+                        jcr:primaryType="nt:unstructured"/>
                     <rtePlugins jcr:primaryType="nt:unstructured">
                         <paraformat
                             jcr:primaryType="nt:unstructured"
@@ -173,7 +188,12 @@
                     allowedTypes="h1"
                     linkDisabled="true"
                     type="h1">
-                    <jcr:content jcr:primaryType="nt:unstructured"/>
+                    <jcr:content
+                        cq:lastReplicated="{Date}2023-06-20T17:56:40.892-06:00"
+                        cq:lastReplicatedBy="admin"
+                        cq:lastReplicationAction="Activate"
+                        jcr:mixinTypes="[cq:ReplicationStatus]"
+                        jcr:primaryType="nt:unstructured"/>
                 </policy_641475696923109>
                 <policy_641528232375303
                     jcr:description="Allows all sizes, but not H1, which is reserved for the main page title."
@@ -183,7 +203,12 @@
                     allowedTypes="[h2,h3,h4,h5,h6]"
                     linkDisabled="false"
                     type="h2">
-                    <jcr:content jcr:primaryType="nt:unstructured"/>
+                    <jcr:content
+                        cq:lastReplicated="{Date}2023-06-20T17:56:40.892-06:00"
+                        cq:lastReplicatedBy="admin"
+                        cq:lastReplicationAction="Activate"
+                        jcr:mixinTypes="[cq:ReplicationStatus]"
+                        jcr:primaryType="nt:unstructured"/>
                 </policy_641528232375303>
             </title>
             <experiencefragment jcr:primaryType="nt:unstructured">
@@ -193,7 +218,12 @@
                     jcr:primaryType="nt:unstructured"
                     jcr:title="Page Header"
                     sling:resourceType="wcm/core/components/policy/policy">
-                    <jcr:content jcr:primaryType="nt:unstructured"/>
+                    <jcr:content
+                        cq:lastReplicated="{Date}2023-06-20T17:56:40.892-06:00"
+                        cq:lastReplicatedBy="admin"
+                        cq:lastReplicationAction="Activate"
+                        jcr:mixinTypes="[cq:ReplicationStatus]"
+                        jcr:primaryType="nt:unstructured"/>
                 </policy_header>
                 <policy_footer
                     cq:styleDefaultElement="footer"
@@ -201,7 +231,12 @@
                     jcr:primaryType="nt:unstructured"
                     jcr:title="Page Footer"
                     sling:resourceType="wcm/core/components/policy/policy">
-                    <jcr:content jcr:primaryType="nt:unstructured"/>
+                    <jcr:content
+                        cq:lastReplicated="{Date}2023-06-20T17:56:40.892-06:00"
+                        cq:lastReplicatedBy="admin"
+                        cq:lastReplicationAction="Activate"
+                        jcr:mixinTypes="[cq:ReplicationStatus]"
+                        jcr:primaryType="nt:unstructured"/>
                 </policy_footer>
             </experiencefragment>
             <container jcr:primaryType="nt:unstructured">
@@ -211,7 +246,12 @@
                     jcr:title="Page Root"
                     sling:resourceType="wcm/core/components/policy/policy"
                     components="[group:AEM Bootcamp Site - Content,/apps/aem-bootcamp/components/form/container,group:AEM Bootcamp Site - Structure]">
-                    <jcr:content jcr:primaryType="nt:unstructured"/>
+                    <jcr:content
+                        cq:lastReplicated="{Date}2023-06-20T17:56:40.892-06:00"
+                        cq:lastReplicatedBy="admin"
+                        cq:lastReplicationAction="Activate"
+                        jcr:mixinTypes="[cq:ReplicationStatus]"
+                        jcr:primaryType="nt:unstructured"/>
                     <cq:authoring jcr:primaryType="nt:unstructured">
                         <assetToComponentMapping jcr:primaryType="nt:unstructured">
                             <mapping_1575024218483
@@ -237,11 +277,19 @@
                 </policy_1574694950110>
                 <policy_1574695586800
                     jcr:description="Allows the page components and defines the component mapping (this configures what components should be automatically created when authors drop assets from the content finder to the page editor)."
+                    jcr:lastModified="{Date}2023-06-20T16:40:08.725-06:00"
+                    jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
                     jcr:title="Page Content"
                     sling:resourceType="wcm/core/components/policy/policy"
-                    components="[group:AEM Bootcamp Site - Content,/apps/aem-bootcamp/components/form/container]">
-                    <jcr:content jcr:primaryType="nt:unstructured"/>
+                    components="[group:AEM Bootcamp General,group:AEM Bootcamp Site - Content,/apps/aem-bootcamp/components/form/container]"
+                    layoutDisabled="false">
+                    <jcr:content
+                        cq:lastReplicated="{Date}2023-06-20T17:56:40.892-06:00"
+                        cq:lastReplicatedBy="admin"
+                        cq:lastReplicationAction="Activate"
+                        jcr:mixinTypes="[cq:ReplicationStatus]"
+                        jcr:primaryType="nt:unstructured"/>
                     <cq:authoring jcr:primaryType="nt:unstructured">
                         <assetToComponentMapping jcr:primaryType="nt:unstructured">
                             <mapping_1575030255082
@@ -271,7 +319,12 @@
                     jcr:primaryType="nt:unstructured"
                     jcr:title="Page Main"
                     sling:resourceType="wcm/core/components/policy/policy">
-                    <jcr:content jcr:primaryType="nt:unstructured"/>
+                    <jcr:content
+                        cq:lastReplicated="{Date}2023-06-20T17:56:40.892-06:00"
+                        cq:lastReplicatedBy="admin"
+                        cq:lastReplicationAction="Activate"
+                        jcr:mixinTypes="[cq:ReplicationStatus]"
+                        jcr:primaryType="nt:unstructured"/>
                 </policy_649128221558427>
                 <policy_1575040440977
                     jcr:description="Allows the template components and defines the component mapping (this configures what components should be automatically created when authors drop assets from the content finder to the page editor)."
@@ -311,7 +364,12 @@
                     jcr:title="Content Teaser"
                     sling:resourceType="wcm/core/components/policy/policy"
                     titleType="h3">
-                    <jcr:content jcr:primaryType="nt:unstructured"/>
+                    <jcr:content
+                        cq:lastReplicated="{Date}2023-06-20T17:56:40.892-06:00"
+                        cq:lastReplicatedBy="admin"
+                        cq:lastReplicationAction="Activate"
+                        jcr:mixinTypes="[cq:ReplicationStatus]"
+                        jcr:primaryType="nt:unstructured"/>
                 </policy_1575031387650>
             </teaser>
             <download jcr:primaryType="nt:unstructured">
@@ -325,20 +383,152 @@
                     displayFormat="true"
                     displaySize="true"
                     titleType="h3">
-                    <jcr:content jcr:primaryType="nt:unstructured"/>
+                    <jcr:content
+                        cq:lastReplicated="{Date}2023-06-20T17:56:40.892-06:00"
+                        cq:lastReplicatedBy="admin"
+                        cq:lastReplicationAction="Activate"
+                        jcr:mixinTypes="[cq:ReplicationStatus]"
+                        jcr:primaryType="nt:unstructured"/>
                 </policy_1575032193319>
             </download>
             <page jcr:primaryType="nt:unstructured">
                 <policy
                     jcr:description="Includes the required client libraries."
+                    jcr:lastModified="{Date}2023-06-23T15:06:36.109-06:00"
+                    jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
                     jcr:title="Generic Page"
                     sling:resourceType="wcm/core/components/policy/policy"
                     clientlibs="[aem-bootcamp.dependencies,aem-bootcamp.site]"
+                    clientlibsAsync="false"
                     clientlibsJsHead="aem-bootcamp.dependencies">
-                    <jcr:content jcr:primaryType="nt:unstructured"/>
+                    <jcr:content
+                        cq:lastReplicated="{Date}2023-06-20T17:56:40.892-06:00"
+                        cq:lastReplicatedBy="admin"
+                        cq:lastReplicationAction="Activate"
+                        jcr:mixinTypes="[cq:ReplicationStatus]"
+                        jcr:primaryType="nt:unstructured"/>
                 </policy>
             </page>
+            <general jcr:primaryType="nt:unstructured">
+                <separator jcr:primaryType="nt:unstructured">
+                    <policy_1687302408035
+                        jcr:description="This is a policy to add custom styles to the deparator component"
+                        jcr:lastModified="{Date}2023-06-22T21:03:46.639-06:00"
+                        jcr:lastModifiedBy="admin"
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Bootcamp Separator Policy"
+                        sling:resourceType="wcm/core/components/policy/policy">
+                        <jcr:content
+                            cq:lastReplicated="{Date}2023-06-20T17:56:40.892-06:00"
+                            cq:lastReplicatedBy="admin"
+                            cq:lastReplicationAction="Activate"
+                            jcr:mixinTypes="[cq:ReplicationStatus]"
+                            jcr:primaryType="nt:unstructured"/>
+                        <cq:styleGroups jcr:primaryType="nt:unstructured">
+                            <item0
+                                cq:styleGroupLabel="show/hide"
+                                jcr:primaryType="nt:unstructured">
+                                <cq:styles jcr:primaryType="nt:unstructured">
+                                    <item0
+                                        cq:styleClasses="bootcamp-separator-show"
+                                        cq:styleId="1687307364698"
+                                        cq:styleLabel="Show"
+                                        jcr:primaryType="nt:unstructured"/>
+                                    <item1
+                                        cq:styleClasses="bootcamp-separator-hide"
+                                        cq:styleId="1687307381828"
+                                        cq:styleLabel="Hide"
+                                        jcr:primaryType="nt:unstructured"/>
+                                </cq:styles>
+                            </item0>
+                            <item1
+                                cq:styleGroupLabel="Colors"
+                                jcr:primaryType="nt:unstructured">
+                                <cq:styles jcr:primaryType="nt:unstructured">
+                                    <item0
+                                        cq:styleClasses="bootcamp-separator-color-grey"
+                                        cq:styleId="1687484383339"
+                                        cq:styleLabel="Grey"
+                                        jcr:primaryType="nt:unstructured"/>
+                                    <item1
+                                        cq:styleClasses="bootcamp-separator-color-black"
+                                        cq:styleId="1687484389030"
+                                        cq:styleLabel="Black"
+                                        jcr:primaryType="nt:unstructured"/>
+                                    <item2
+                                        cq:styleClasses="bootcamp-separator-color-white"
+                                        cq:styleId="1687484394278"
+                                        cq:styleLabel="White"
+                                        jcr:primaryType="nt:unstructured"/>
+                                    <item3
+                                        cq:styleClasses="bootcamp-separator-color-yellow"
+                                        cq:styleId="1687484400023"
+                                        cq:styleLabel="Yellow"
+                                        jcr:primaryType="nt:unstructured"/>
+                                    <item4
+                                        cq:styleClasses="bootcamp-separator-color-red"
+                                        cq:styleId="1687484404867"
+                                        cq:styleLabel="Red"
+                                        jcr:primaryType="nt:unstructured"/>
+                                    <item5
+                                        cq:styleClasses="bootcamp-separator-color-blue"
+                                        cq:styleId="1687484410919"
+                                        cq:styleLabel="Blue"
+                                        jcr:primaryType="nt:unstructured"/>
+                                </cq:styles>
+                            </item1>
+                            <item2
+                                cq:styleGroupLabel="Thickness"
+                                jcr:primaryType="nt:unstructured">
+                                <cq:styles jcr:primaryType="nt:unstructured">
+                                    <item0
+                                        cq:styleClasses="bootcamp-separator-width-30"
+                                        cq:styleId="1687484477467"
+                                        cq:styleLabel="30 %"
+                                        jcr:primaryType="nt:unstructured"/>
+                                    <item1
+                                        cq:styleClasses="bootcamp-separator-width-50"
+                                        cq:styleId="1687484493502"
+                                        cq:styleLabel="50 %"
+                                        jcr:primaryType="nt:unstructured"/>
+                                    <item2
+                                        cq:styleClasses="bootcamp-separator-width-80"
+                                        cq:styleId="1687484503857"
+                                        cq:styleLabel="80 %"
+                                        jcr:primaryType="nt:unstructured"/>
+                                    <item3
+                                        cq:styleClasses="bootcamp-separator-width-100"
+                                        cq:styleId="1687484519886"
+                                        cq:styleLabel="100 %"
+                                        jcr:primaryType="nt:unstructured"/>
+                                </cq:styles>
+                            </item2>
+                            <item3
+                                cq:styleGroupLabel="Separator Style"
+                                jcr:primaryType="nt:unstructured">
+                                <cq:styles jcr:primaryType="nt:unstructured">
+                                    <item0
+                                        cq:styleClasses="bootcamp-separator-solid"
+                                        cq:styleId="1687484542909"
+                                        cq:styleLabel="Solid"
+                                        jcr:primaryType="nt:unstructured"/>
+                                    <item1
+                                        cq:styleClasses="bootcamp-separator-dashed"
+                                        cq:styleId="1687484554471"
+                                        cq:styleLabel="Dashed"
+                                        jcr:primaryType="nt:unstructured"/>
+                                    <item2
+                                        cq:styleClasses="bootcamp-separator-dotted"
+                                        cq:styleId="1687484581661"
+                                        cq:styleLabel="Dotted"
+                                        jcr:primaryType="nt:unstructured"/>
+                                </cq:styles>
+                            </item3>
+                        </cq:styleGroups>
+                    </policy_1687302408035>
+                </separator>
+            </general>
         </components>
     </aem-bootcamp>
 </jcr:root>


### PR DESCRIPTION
this is to add a custom separator including the following requirements:

- Author should be able to show/hide the separator if added to page.
- Author should be able to change color of the separator. Colors like

1. Grey
2. Black
3. White
4. Yellow
5. Red
6. Blue

- Author should be able to change thickness of the separator.
- Author should be able to change style of separator like solid, dashed, dotted.
- Separator component will not have a dialog-box.

![image](https://github.com/altperf/aem-bootcamp/assets/136115127/69de365b-c81e-49b2-b979-999ab9614906)
